### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/Spring/post-example/src/main/java/com/practice/postexample/repository/ArticleCommentRepository.java
+++ b/Spring/post-example/src/main/java/com/practice/postexample/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.practice.postexample.repository;
 
 import com.practice.postexample.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/Spring/post-example/src/main/java/com/practice/postexample/repository/ArticleRepository.java
+++ b/Spring/post-example/src/main/java/com/practice/postexample/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.practice.postexample.repository;
 
 import com.practice.postexample.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/Spring/post-example/src/main/resources/application.yml
+++ b/Spring/post-example/src/main/resources/application.yml
@@ -30,6 +30,7 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+
   #테스트시 활성화
 #  h2:
 #    console:
@@ -37,6 +38,12 @@ spring:
   sql:
     init:
       mode: always
+
+  #Spring Data Rest Setting
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 
 ---
 

--- a/Spring/post-example/src/test/java/com/practice/postexample/controller/DataRestTest.java
+++ b/Spring/post-example/src/test/java/com/practice/postexample/controller/DataRestTest.java
@@ -1,0 +1,85 @@
+package com.practice.postexample.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data Rest - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Test
+    @DisplayName("[API] 게시글 리스트 조회")
+    void getArticleListApiTest() throws Exception {
+        //given
+
+        //when
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @Test
+    @DisplayName("[API] 게시글 단건 조회")
+    void get_SingleArticle_ApiTest() throws Exception {
+        //given
+
+        //when
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @Test
+    @DisplayName("[API] 게시글 -> 댓글 리스트 조회")
+    void get_ArticleCommentListFromSingleArticle_ApiTest() throws Exception {
+        //given
+
+        //when
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+    @Test
+    @DisplayName("[API] 댓글 단건 조회")
+    void get_SingleArticleComment_ApiTest() throws Exception {
+        //given
+
+        //when
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+
+        //then
+    }
+
+}


### PR DESCRIPTION
게시글 / 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 API들의 존재 여부만 체크하는 걸로 통합테스트 작성